### PR TITLE
[Feat -> Dev] Refresh Token Header 전송

### DIFF
--- a/server/src/main/java/codestates/frogroup/indiego/config/AES128Config.java
+++ b/server/src/main/java/codestates/frogroup/indiego/config/AES128Config.java
@@ -1,0 +1,51 @@
+package codestates.frogroup.indiego.config;
+
+
+import codestates.frogroup.indiego.global.exception.BusinessLogicException;
+import codestates.frogroup.indiego.global.exception.ExceptionCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Component
+public class AES128Config {
+
+    @Value("${aes.secret-key}")
+    private String secretKey;
+    private byte[] key; // 16,24,32 byte 중 고정
+
+    @PostConstruct
+    public void init(){
+        this.key = secretKey.substring(0,24).getBytes();
+    }
+
+    // AES 암호화
+    public String encryptAes(String str) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES");
+            SecretKeySpec secretKey = new SecretKeySpec(key,"AES");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            byte[] encPassword = cipher.doFinal(str.getBytes("UTF-8"));
+            return Base64.getEncoder().encodeToString(encPassword);
+        } catch (Exception e){
+            throw new BusinessLogicException(ExceptionCode.ENCRYPTION_FAIED);
+        }
+    }
+
+    // AES 복호화
+    public String decryptAes(String str) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES");
+            SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey);
+            byte[] decPassword = cipher.doFinal(Base64.getDecoder().decode(str));
+            return new String(decPassword, "UTF-8");
+        } catch (Exception e){
+            throw new BusinessLogicException(ExceptionCode.DECRYPTION_FAIED);
+        }
+    }
+}

--- a/server/src/main/java/codestates/frogroup/indiego/config/PasswordEncoderConfig.java
+++ b/server/src/main/java/codestates/frogroup/indiego/config/PasswordEncoderConfig.java
@@ -1,4 +1,4 @@
-package codestates.frogroup.indiego.global.security.config;
+package codestates.frogroup.indiego.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/server/src/main/java/codestates/frogroup/indiego/domain/member/controller/MemberController.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/member/controller/MemberController.java
@@ -94,18 +94,18 @@ public class MemberController {
     }
 
     @GetMapping("/reissue")
-    public ResponseEntity reissue(@CookieValue(value = "refreshToken", required = false) String refreshToken,
-                                  HttpServletRequest request,
+    public ResponseEntity reissue(HttpServletRequest request,
                                   HttpServletResponse response){
+        // @CookieValue(value = "refreshToken", required = false) String refreshToken // 쿠키사용
 
-        memberService.reissueAccessToken(refreshToken,request,response);
+        memberService.reissueAccessToken(request,response);
         return new ResponseEntity(new SingleResponseDto<>("Access Token 재발급 완료!"),HttpStatus.CREATED);
     }
 
     @GetMapping("/logout")
-    public ResponseEntity logout(@CookieValue(value = "refreshToken", required = false) String refreshToken){
-
-        memberService.logout(refreshToken);
+    public ResponseEntity logout(HttpServletRequest request){
+        // @CookieValue(value = "refreshToken", required = false) String refreshToken // 쿠키사용
+        memberService.logout(request);
         return new ResponseEntity<>(new SingleResponseDto<>("로그아웃에 성공하였습니다."), HttpStatus.CREATED);
     }
 

--- a/server/src/main/java/codestates/frogroup/indiego/global/exception/ExceptionCode.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/exception/ExceptionCode.java
@@ -13,7 +13,7 @@ public enum ExceptionCode {
     // JWT, 인증관련
     ACCESS_TOKEN_NOT_FOUND(404,"Access Token을 찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(404,"Refresh Token을 찾을 수 없습니다."),
-    COOKIE_REFRESH_TOKEN_NOT_FOUND(404,"Cookie 정보에 Refresh Token 정보가 없습니다."),
+    HEADER_REFRESH_TOKEN_NOT_FOUND(404,"Header 정보에 Refresh Token 정보가 없습니다."),
     TOKEN_IS_NOT_SAME(404,"Refresh Token과 발급된 Access Token 정보가 일치하지 않습니다."),
     NO_ACCESS_TOKEN(403, "권한 정보가 없는 토큰입니다."),
     TOKEN_EXPIRED(400, "Token Expired"),
@@ -41,7 +41,11 @@ public enum ExceptionCode {
 
     // File Upload
     UPLOAD_FAILED(404, "File Upload Failed !"),
-    UPLOAD_VOLUME_OVER(404, "File Size가 10MB를 초과하였습니다 !");
+    UPLOAD_VOLUME_OVER(404, "File Size가 10MB를 초과하였습니다 !"),
+
+    // AES
+    ENCRYPTION_FAIED(404, "암호화에 실패하였습니다."),
+    DECRYPTION_FAIED(404, "복호화에 실패하였습니다.");
 
     @Getter
     private int status;

--- a/server/src/main/java/codestates/frogroup/indiego/global/security/auth/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/security/auth/filter/JwtVerificationFilter.java
@@ -47,7 +47,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
         try {
             // 헤더에서 AccessToken 토큰 꺼내오기
-            String jwt = tokenProvider.resolveToken(request);
+            String jwt = tokenProvider.resolveAccessToken(request);
 
             // 토큰 검증을 통과하면 다음 필터 진행
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt,response)) {

--- a/server/src/main/java/codestates/frogroup/indiego/global/security/auth/jwt/TokenProvider.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/security/auth/jwt/TokenProvider.java
@@ -36,6 +36,7 @@ public class TokenProvider {
 	 */
 	public static final String BEARER_TYPE = "Bearer";
 	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String REFRESH_HEADER = "Refresh";
 	public static final String BEARER_PREFIX = "Bearer ";
 
 	@Getter
@@ -162,12 +163,12 @@ public class TokenProvider {
 	public void accessTokenSetHeader(String accessToken, HttpServletResponse response){
 		String headerValue = BEARER_PREFIX + accessToken;
 		response.setHeader(AUTHORIZATION_HEADER,headerValue);
-		log.info("# accessToken = {}",headerValue);
+		//log.info("# accessToken = {}",headerValue);
 	}
 
 	public void refreshTokenSetHeader(String refreshToken, HttpServletResponse response){
 		response.setHeader("Refresh",refreshToken);
-		log.info("# refreshToken = {}",refreshToken);
+		//log.info("# refreshToken = {}",refreshToken);
 	}
 
 	public ResponseCookie refreshTokenSetCookie(String refreshToken, HttpServletResponse response){
@@ -185,12 +186,20 @@ public class TokenProvider {
 
 
 	// Request Header Access Token 정보를 꺼내오는 메소드
-	public String resolveToken(HttpServletRequest request) {
+	public String resolveAccessToken(HttpServletRequest request) {
 		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
 			return bearerToken.substring(7);
 		}
+		return null;
+	}
 
+	// Request Header Refresh Token 정보를 꺼내오는 메소드
+	public String resolveRefreshToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(REFRESH_HEADER);
+		if (StringUtils.hasText(bearerToken)) {
+			return bearerToken;
+		}
 		return null;
 	}
 

--- a/server/src/main/java/codestates/frogroup/indiego/global/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/security/config/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package codestates.frogroup.indiego.global.security.config;
 
+import codestates.frogroup.indiego.config.AES128Config;
 import codestates.frogroup.indiego.domain.member.service.MemberService;
 import codestates.frogroup.indiego.global.redis.RedisDao;
 import codestates.frogroup.indiego.global.security.auth.filter.JwtAuthenticationFilter;
@@ -10,6 +11,7 @@ import codestates.frogroup.indiego.global.security.auth.oauth.OAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +32,7 @@ public class SecurityConfiguration {
 	private final OAuthService oAuthService;
 	private final MemberService memberService;
 	private final RedisDao redisDao;
+	private final AES128Config aes128Config;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -50,24 +53,24 @@ public class SecurityConfiguration {
 				.apply(new CustomFilterConfigurer())
 				.and()
 				.authorizeHttpRequests(authorize -> authorize
-//						.antMatchers(HttpMethod.POST, "/members/login").permitAll()
-//						.antMatchers(HttpMethod.POST, "/members/signup").permitAll()
-//						.antMatchers(HttpMethod.POST, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PATCH, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PUT, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.DELETE, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.POST, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PATCH, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PUT, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.DELETE, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.POST, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PATCH, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.PUT, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
-//						.antMatchers(HttpMethod.DELETE, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.POST, "/members/login").permitAll()
+						.antMatchers(HttpMethod.POST, "/members/signup").permitAll()
+						.antMatchers(HttpMethod.POST, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PATCH, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PUT, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.DELETE, "/members/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.POST, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PATCH, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PUT, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.DELETE, "/shows/**").hasAnyRole("PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.POST, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PATCH, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.PUT, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
+						.antMatchers(HttpMethod.DELETE, "/articles/**").hasAnyRole("USER","PERFORMER","ADMIN")
 						.anyRequest().permitAll()
 				)
 				.oauth2Login(oauth2 -> oauth2
-						.successHandler(new OAuth2MemberSuccessHandler(tokenProvider,memberService,redisDao))
+						.successHandler(new OAuth2MemberSuccessHandler(tokenProvider,memberService,redisDao,aes128Config))
 						.userInfoEndpoint() // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때 설정 담당
 						.userService(oAuthService)
 				); // OAuth2 로그인 설정 시작점
@@ -79,7 +82,7 @@ public class SecurityConfiguration {
 		CorsConfiguration configuration = new CorsConfiguration();
 		configuration.setAllowedOrigins(List.of("http://localhost:3000",
 				"https://localhost:3000",
-				"http://localhost",
+				"http://localhost", // 로컬환경 OAuth2 테스트용
 				"http://localhost:8080",
 //				"http://13.125.98.211:80",
 				"http://indiego.kro.kr:80"));
@@ -100,9 +103,10 @@ public class SecurityConfiguration {
 		public void configure(HttpSecurity builder) throws Exception {
 			AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 
-			JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, memberService, tokenProvider, redisDao);
+			JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager,
+					memberService, tokenProvider, redisDao, aes128Config);
 			jwtAuthenticationFilter.setFilterProcessesUrl("/members/login");
-			jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler()); // 추후 refreshTokenRepository 넣기
+			jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler());
 			jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());
 
 			JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(tokenProvider);


### PR DESCRIPTION
1. Refresh Token 암복호화 기능 추가 (AES128)
2. Refresh Token Header로 전송하도록 변경 (일반로그인)
3. Security 권한 부분 주석 해제
4. AES128 Config 추가에 따른 예외 로직 추가
5. OAuth2 소셜로그인 param으로 전달하도록 변경
6. 쿠키 관련 로직 주석 처리

📌 *참고 사항*
application.yml 파일에 

aes:
  secret-key: ${AES_SECRET_KEY}  # 환경 변수로 설정했음
를 설정해주셔야합니다!!